### PR TITLE
[Refactor] 위치기반 검색 서비스 계산방법 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'org.hibernate.orm:hibernate-spatial'
 	implementation 'com.querydsl:querydsl-spatial'
-	implementation 'org.locationtech.jts:jts-core:1.19.0'
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	implementation 'io.minio:minio:8.5.12'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/trendravel/photoravel_be/db/respository/location/LocationRepositoryImpl.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/location/LocationRepositoryImpl.java
@@ -87,8 +87,10 @@ public class LocationRepositoryImpl implements LocationRepositoryCustom{
         }
         points.setSRID(4326);
 
-        return Expressions.booleanTemplate("ST_Contains(ST_BUFFER({0}, {1}), {2})",
-                points, range, location.point);
+        return Expressions.booleanTemplate(
+                "ST_Distance_Sphere(ST_GeomFromText({0}, 4326), {1}) <= {2}",
+                points.toText(), location.point, range
+        );
     }
 
     @Override


### PR DESCRIPTION
# 변경내용
## 기존 연산방식 
좌표평면계에서 사용하는 유클리드 거리 계산 방식

## 변경 연산방식
구면좌표계에서 사용하는 하버사인 거리 계산 방식

# 변경사유
## 문제 발생
- 지구는 구형태이므로 기존방식의 경우 거리 오차 발생
- SRID 4326의 경우 탐색 범위를 미터(m)단위에서 도(degree) 단위로 변경하는데, 이때 오차발생

사용자에게 정확한 데이터를 제공하기 위해 오차발생 문제를 해결하고자 변경함