### PR TITLE
[Refactor] 프로필에 따른 S3Client 변경작업 통일

### DIFF
--- a/src/main/java/trendravel/photoravel_be/common/image/service/ImageService.java
+++ b/src/main/java/trendravel/photoravel_be/common/image/service/ImageService.java
@@ -22,20 +22,16 @@ import java.util.List;
 public class ImageService{
 
 
-    private final S3Client amazonS3;
-    private final S3Client minioClient;
+    private final S3Client imageStorage;
 
-
-
-    @Value("${spring.cloud.aws.s3.bucket}")
+    @Value("${storage.bucket.name}")
     private String bucketName;
 
     public void uploadImages(List<MultipartFile> images, List<String> rebuildImageName){
         if(images == null){
             return;
         }
-        uploadImageToStorage(images, rebuildImageName, minioClient);
-//      uploadImageToStorage(images, rebuildImageName, amazonS3);
+        uploadImageToStorage(images, rebuildImageName, imageStorage);
     }
 
 
@@ -63,8 +59,7 @@ public class ImageService{
      */
 
     public void deleteAllImages(List<String> deleteImages){
-        deleteImagesInStorage(deleteImages, minioClient);
-//        deleteImagesInStorage(deleteImages, amazonS3);
+        deleteImagesInStorage(deleteImages, imageStorage);
     }
 
     private void deleteImagesInStorage(List<String> deleteImages, S3Client storage) {

--- a/src/main/java/trendravel/photoravel_be/config/S3Config.java
+++ b/src/main/java/trendravel/photoravel_be/config/S3Config.java
@@ -9,7 +9,6 @@ import software.amazon.awssdk.auth.credentials.*;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
-import java.net.URI;
 
 @Configuration
 @Profile({"prod","test"})
@@ -34,11 +33,6 @@ public class S3Config {
                                 .create(accessKey, accessSecret)))
                 .build();
     }
-
-
-
-
-
 
 
 }

--- a/src/main/java/trendravel/photoravel_be/config/S3ConfigInLocal.java
+++ b/src/main/java/trendravel/photoravel_be/config/S3ConfigInLocal.java
@@ -14,9 +14,9 @@ import java.net.URI;
 
 @Configuration
 @Profile({"dev"})
-public class S3ConfigInLocal extends S3Config{
+public class S3ConfigInLocal{
 
-    @Value("${spring.cloud.aws.region.static}")
+    @Value("${minio.region.static}")
     private String region;
 
     @Value("${minio.access.key}")
@@ -41,7 +41,4 @@ public class S3ConfigInLocal extends S3Config{
                 .forcePathStyle(true)
                 .build();
     }
-
-
-
 }


### PR DESCRIPTION
# bucket region 경로 변경
- dev Profile의 경우 s3가 아닌 minio region경로 참조하도록 변경했습니다

# S3Client 기능 통합
## 기존 문제
- 프로필 설정에 따라, 사전에 코드를 변경해야했습니다
- EX) dev 프로필은 minioClient를,  prod 프로필은 amazonS3를 사용해야했습니다

## 해결
- 이제 프로필 구분없이 통일된 imageStorage를 통해 사용할 수 있습니다
- 별도의 코드 수정이 필요없습니다.

# bucket name 설정 경로 변경
- 프로필에 따라 bucket name이 다르며, 공통되는 prefix도 없기 때문에 공통 설정으로 변경 후 적용햇씁니다